### PR TITLE
ログに日付が重複しないように変更

### DIFF
--- a/form.jade
+++ b/form.jade
@@ -12,4 +12,6 @@ html(lang="jp")
       span #{firstItem} 
       input(type="radio", name="favorite", value="#{secondItem}")
       span #{secondItem} 
+      input(type="radio", name="favorite", value="吉村先生")
+      span 吉村先生 
       button(type="submit") 投稿

--- a/index.js
+++ b/index.js
@@ -2,8 +2,11 @@
 const http = require('http');
 const jade = require('jade');
 const server = http.createServer((req, res) => {
-  const now = new Date();
-  console.info('[' + now + '] Requested by ' + req.connection.remoteAddress);
+
+  // 2016Oct23 ログが重複しないように、 now を変更。なお変更箇所は ３箇所。
+  //const now = new Date();
+
+  console.info(' Requested by ' + req.connection.remoteAddress);
   res.writeHead(200, {
     'Content-Type': 'text/html',
     'charset': 'utf-8'
@@ -35,7 +38,7 @@ const server = http.createServer((req, res) => {
     case 'POST':
       req.on('data', (data) => {
         const decoded = decodeURIComponent(data);
-        console.info('[' + now + '] 投稿: ' + decoded);
+        console.info('投稿: ' + decoded);
         res.write('<!DOCTYPE html><html lang="ja"><head><meta charset="utf-8"></head><body><h1>' +
           decoded + 'が投稿されました</h1></body></html>');
         res.end();


### PR DESCRIPTION
練習用なので、マージは不要です。
アイコンを変更しました。（ニコニコ内のフリー素材）

放送時に、 heroku が落ちていたのは、
10月21日の午前11時ごろ（協定世界時、日本との時差は9時間）
米DNSサービスに大規模DDoS攻撃で米国でTwitterやSpotifyが長時間ダウン
http://www.itmedia.co.jp/news/articles/1610/22/news024.html
の影響だったのかもしれないですね。